### PR TITLE
Add upload size check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# AI Nutrition Scanner
+
+This WordPress plugin allows scanning nutrition labels and parsing their contents using OCR and GPT.
+
+## Manual Test: Oversized Image Rejection
+
+1. Encode an image larger than 5 MB as a base64 data URI.
+2. Submit the data to the plugin's `anp_scan` AJAX endpoint (e.g. via browser console or a custom form).
+3. The request should fail and return an error message `Image exceeds 5 MB limit`.
+
+This confirms that the plugin correctly rejects oversized images before attempting to save them.


### PR DESCRIPTION
## Summary
- compute byte size from base64 before decoding in `anp_save_image`
- reject images over 5 MB
- document manual test for oversized images

## Testing
- `php -l ai-nutrition-scanner.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843754a38a88331b0c8981e7ce706b8