### PR TITLE
Update scan tiles for missing data

### DIFF
--- a/assets/css/anp-styles.css
+++ b/assets/css/anp-styles.css
@@ -53,3 +53,7 @@
   transform: translateY(-50%);
   font-size: 1.1rem;
 }
+
+.anp-product-tile {
+  font-weight: bold;
+}

--- a/assets/js/anp-scripts.js
+++ b/assets/js/anp-scripts.js
@@ -94,11 +94,31 @@ function resizeAndSend(file) {
   function renderTiles(analysis) {
     const container = $('#anp-tiles').empty();
 
+    if (analysis.product_name) {
+      container.append(
+        $('<div>')
+          .addClass('anp-tile anp-product-tile')
+          .text('Product: ' + analysis.product_name)
+      );
+    } else {
+      container.append(
+        $('<div>')
+          .addClass('anp-tile anp-product-tile')
+          .text('No product name available')
+      );
+    }
+
     if (analysis.expiry_date) {
       const expiry = $('<div>')
         .addClass('anp-tile anp-expiry-tile')
         .text('Expiry: ' + analysis.expiry_date);
       container.append(expiry);
+    } else {
+      container.append(
+        $('<div>')
+          .addClass('anp-tile anp-expiry-tile')
+          .text('No expiry date available')
+      );
     }
 
     if (Array.isArray(analysis.flags) && analysis.flags.length) {
@@ -122,6 +142,7 @@ function resizeAndSend(file) {
         protein_g: 'Protein (g)',
         salt_g: 'Salt (g)'
       };
+      let anyNut = false;
       Object.keys(names).forEach(key => {
         const val = analysis.nutrition[key];
         if (val == null) return;
@@ -129,9 +150,23 @@ function resizeAndSend(file) {
         const tile = $('<div>')
           .addClass('anp-tile anp-nutrition-tile');
         if (lvl) tile.addClass('anp-level-' + lvl);
-        tile.text(names[key] + ': ' + val);
+        tile.text(names[key]);
         container.append(tile);
+        anyNut = true;
       });
+      if (!anyNut) {
+        container.append(
+          $('<div>')
+            .addClass('anp-tile anp-nutrition-tile')
+            .text('No nutrition data available')
+        );
+      }
+    } else {
+      container.append(
+        $('<div>')
+          .addClass('anp-tile anp-nutrition-tile')
+          .text('No nutrition data available')
+      );
     }
 
     if (analysis.summary) {


### PR DESCRIPTION
## Summary
- bump plugin version to 1.1.3
- add product name to the GPT extraction and return
- show product and expiry tiles even when missing
- hide numeric values and handle missing nutrition data
- tweak styles for product tile

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441c81bc6883319202ef03022e40ee