### PR TITLE
Add Node-based test suite

### DIFF
--- a/assets/js/anp-scripts.js
+++ b/assets/js/anp-scripts.js
@@ -93,6 +93,11 @@ function resizeAndSend(file) {
       console.error(err);
     });
   }
+
+  // Temporary alias for older code referencing sendToServer
+  function sendToServer(base64Image) {
+    sendScan(base64Image);
+  }
   // ----- Render result tiles -----
   function renderTiles(analysis) {
     const container = $('#anp-tiles').empty();
@@ -187,5 +192,14 @@ function resizeAndSend(file) {
       tile.append($('<p>').text(alt));
       container.append(tile);
     }
+  }
+  // Expose helpers for testing and legacy support
+  if (typeof window !== 'undefined') {
+    window.classifyNutrient = classifyNutrient;
+    window.sendScan = sendScan;
+    window.sendToServer = sendToServer;
+  }
+  if (typeof module !== 'undefined') {
+    module.exports = { classifyNutrient, sendScan };
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-food-label-scanner",
+  "version": "1.0.0",
+  "description": "Development utilities for the AI Nutrition Scanner plugin",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/anp-scripts.test.js
+++ b/tests/anp-scripts.test.js
@@ -1,0 +1,45 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+// Stub a minimal jQuery implementation so the plugin code can execute in Node
+function stubElement() {
+  return {
+    on: () => stubElement(),
+    trigger: () => stubElement(),
+    append: () => stubElement(),
+    hide: () => stubElement(),
+    show: () => stubElement(),
+    text: () => stubElement(),
+    empty: () => stubElement(),
+    addClass: () => stubElement()
+  };
+}
+
+global.jQuery = (arg) => {
+  if (typeof arg === 'function') {
+    arg(global.jQuery);
+    return stubElement();
+  }
+  return stubElement();
+};
+
+const { classifyNutrient } = require('../assets/js/anp-scripts');
+
+describe('classifyNutrient', () => {
+  it('returns null for invalid inputs', () => {
+    assert.strictEqual(classifyNutrient('energy_kcal', null), null);
+    assert.strictEqual(classifyNutrient('energy_kcal', 'abc'), null);
+    assert.strictEqual(classifyNutrient('unknown', 10), null);
+  });
+
+  it('classifies energy correctly', () => {
+    assert.strictEqual(classifyNutrient('energy_kcal', 100), 'low');
+    assert.strictEqual(classifyNutrient('energy_kcal', 200), 'medium');
+    assert.strictEqual(classifyNutrient('energy_kcal', 400), 'high');
+  });
+
+  it('inverts classification for fiber', () => {
+    assert.strictEqual(classifyNutrient('fiber_g', 2), 'high');
+    assert.strictEqual(classifyNutrient('fiber_g', 4), 'medium');
+    assert.strictEqual(classifyNutrient('fiber_g', 7), 'low');
+  });
+});


### PR DESCRIPTION
## Summary
- make plugin JS testable in Node by exposing `classifyNutrient`
- add minimal Node-based tests using the built-in test runner
- update `package.json` to run tests
- add `sendToServer` alias for backwards compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68442f4ec0648331ad617a88be75c3ca