### PR TITLE
Add PHP unit test scaffolding

### DIFF
--- a/assets/js/anp-scripts.js
+++ b/assets/js/anp-scripts.js
@@ -93,6 +93,11 @@ function resizeAndSend(file) {
       console.error(err);
     });
   }
+
+  // Temporary alias for older code referencing sendToServer
+  function sendToServer(base64Image) {
+    sendScan(base64Image);
+  }
   // ----- Render result tiles -----
   function renderTiles(analysis) {
     const container = $('#anp-tiles').empty();
@@ -187,5 +192,14 @@ function resizeAndSend(file) {
       tile.append($('<p>').text(alt));
       container.append(tile);
     }
+  }
+  // Expose helpers for testing and legacy support
+  if (typeof window !== 'undefined') {
+    window.classifyNutrient = classifyNutrient;
+    window.sendScan = sendScan;
+    window.sendToServer = sendToServer;
+  }
+  if (typeof module !== 'undefined') {
+    module.exports = { classifyNutrient, sendScan };
   }
 });

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-food-label-scanner/plugin-tests",
+  "description": "PHP unit tests for the AI Nutrition Scanner plugin",
+  "require-dev": {
+    "phpunit/phpunit": "^9"
+  },
+  "autoload": {
+    "files": ["ai-nutrition-scanner.php"]
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-food-label-scanner",
+  "version": "1.0.0",
+  "description": "Development utilities for the AI Nutrition Scanner plugin",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/php/bootstrap.php">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory>tests/php</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/anp-scripts.test.js
+++ b/tests/anp-scripts.test.js
@@ -1,0 +1,45 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+// Stub a minimal jQuery implementation so the plugin code can execute in Node
+function stubElement() {
+  return {
+    on: () => stubElement(),
+    trigger: () => stubElement(),
+    append: () => stubElement(),
+    hide: () => stubElement(),
+    show: () => stubElement(),
+    text: () => stubElement(),
+    empty: () => stubElement(),
+    addClass: () => stubElement()
+  };
+}
+
+global.jQuery = (arg) => {
+  if (typeof arg === 'function') {
+    arg(global.jQuery);
+    return stubElement();
+  }
+  return stubElement();
+};
+
+const { classifyNutrient } = require('../assets/js/anp-scripts');
+
+describe('classifyNutrient', () => {
+  it('returns null for invalid inputs', () => {
+    assert.strictEqual(classifyNutrient('energy_kcal', null), null);
+    assert.strictEqual(classifyNutrient('energy_kcal', 'abc'), null);
+    assert.strictEqual(classifyNutrient('unknown', 10), null);
+  });
+
+  it('classifies energy correctly', () => {
+    assert.strictEqual(classifyNutrient('energy_kcal', 100), 'low');
+    assert.strictEqual(classifyNutrient('energy_kcal', 200), 'medium');
+    assert.strictEqual(classifyNutrient('energy_kcal', 400), 'high');
+  });
+
+  it('inverts classification for fiber', () => {
+    assert.strictEqual(classifyNutrient('fiber_g', 2), 'high');
+    assert.strictEqual(classifyNutrient('fiber_g', 4), 'medium');
+    assert.strictEqual(classifyNutrient('fiber_g', 7), 'low');
+  });
+});

--- a/tests/php/OpenAIExtractTest.php
+++ b/tests/php/OpenAIExtractTest.php
@@ -1,0 +1,17 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/bootstrap.php';
+
+class OpenAIExtractTest extends TestCase {
+    public function testReturnsDefaultsWithoutApiKey() {
+        $out = anp_openai_extract_after_clean('nutrition text');
+        $this->assertSame([
+            'product_name'=> null,
+            'expiry_date' => null,
+            'flags'       => [],
+            'nutrition'   => [],
+            'summary'     => '',
+            'alternative' => '',
+        ], $out);
+    }
+}

--- a/tests/php/SaveImageTest.php
+++ b/tests/php/SaveImageTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/bootstrap.php';
+
+class SaveImageTest extends TestCase {
+    public function testRejectsInvalidBase64() {
+        $res = anp_save_image('invalid');
+        $this->assertInstanceOf(WP_Error::class, $res);
+        $this->assertSame('Invalid image format', $res->get_error_message());
+    }
+
+    public function testRejectsOversizeImage() {
+        $data = random_bytes(6 * 1024 * 1024); // 6 MB
+        $b64  = 'data:image/png;base64,' . base64_encode($data);
+        $res = anp_save_image($b64);
+        $this->assertInstanceOf(WP_Error::class, $res);
+        $this->assertSame('Image exceeds 5 MB limit', $res->get_error_message());
+    }
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,36 @@
+<?php
+// Minimal WordPress stubs for running plugin functions in tests
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        protected $message;
+        public function __construct($code = '', $message = '') {
+            $this->message = $message;
+        }
+        public function get_error_message() {
+            return $this->message;
+        }
+    }
+}
+
+function plugin_dir_path($file) { return __DIR__; }
+function plugin_dir_url($file) { return 'http://example.com/'; }
+function wp_enqueue_style() {}
+function wp_enqueue_script() {}
+function wp_localize_script() {}
+function wp_create_nonce($key) { return 'nonce'; }
+function admin_url($path='') { return $path; }
+function add_action() {}
+function add_shortcode() {}
+function add_options_page() {}
+function register_activation_hook() {}
+
+function get_option($name) { return null; }
+function wp_upload_bits($filename, $placeholder, $data) {
+    return ['file' => '/tmp/'.$filename, 'url' => 'http://example.com/'.$filename, 'error' => ''];
+}
+function wp_remote_post($url, $args=array()) { return ['body' => '{}']; }
+function wp_remote_get($url, $args=array()) { return ['body' => '{}']; }
+function wp_remote_retrieve_body($res) { return $res['body'] ?? ''; }
+function wp_json_encode($data) { return json_encode($data); }
+
+require_once __DIR__ . '/../../ai-nutrition-scanner.php';


### PR DESCRIPTION
## Summary
- add `composer.json` with phpunit setup
- provide phpunit configuration
- stub minimal WordPress functions in `tests/php/bootstrap.php`
- add tests for `anp_save_image` and `anp_openai_extract_after_clean`

## Testing
- `npm test`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442f4ec0648331ad617a88be75c3ca